### PR TITLE
Change the Style color of the attribute back to current for light theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -108,7 +108,7 @@
 }
 
 .statblock-tor2e .attr-diamond-text {
-	color: #fff;
+	color: var(--currentcolor);
 	display: table-cell;
 	width: 2em;
 	height: 2em;


### PR DESCRIPTION
Please, consider this change because the colour WHITE is not visible when you render the stats using a Light Obsidian Theme.